### PR TITLE
Check if both slack token and slack channel present

### DIFF
--- a/tests/integration/test_hooks_slack.py
+++ b/tests/integration/test_hooks_slack.py
@@ -31,6 +31,11 @@ def repo():
         yield repo
 
 
+@pytest.fixture(autouse=True)
+def mock_verify_attributes(monkeypatch):
+    monkeypatch.setattr(__name__ + '.uut.Hook._verify_settings', lambda x: None)
+
+
 @pytest.mark.parametrize(['slack_response', 'result'], [
     [{'messages': []}, None],
 ])

--- a/tests/unit/test_hooks_slack.py
+++ b/tests/unit/test_hooks_slack.py
@@ -1,0 +1,21 @@
+import pytest
+
+from crane import settings
+from crane.exc import UpgradeFailed
+from crane.hooks.slack import Hook as SlackHook
+
+
+def test_without_slack_channel(monkeypatch):
+    monkeypatch.setitem(settings, 'slack_token', 'some token')
+    monkeypatch.setitem(settings, 'slack_channel', None)
+
+    with pytest.raises(UpgradeFailed):
+        SlackHook()
+
+
+def test_without_slack_token(monkeypatch):
+    monkeypatch.setitem(settings, 'slack_token', None)
+    monkeypatch.setitem(settings, 'slack_channel', 'some channel')
+
+    with pytest.raises(UpgradeFailed):
+        SlackHook()


### PR DESCRIPTION
Happened to me, that I set up `CRANE_SLACK_TOKEN` environment variable, but forgot about  `CRANE_SLACK_CHANNEL`. `Crane` have failed without any warning. This is always better explicitly say to user that he forgot something. 

This pull request suggests to throw an error  with a message if user did not set up either  `CRANE_SLACK_TOKEN` or `CRANE_SLACK_CHANNEL`.